### PR TITLE
skip "\r" characters where one would skip "\n" characters

### DIFF
--- a/sexpr/parser.py
+++ b/sexpr/parser.py
@@ -78,7 +78,7 @@ def breakAt(m,st):
 def parseItem(st):
     ret = []
     while True:
-        s = dropTill(lambda x: not x in " \n"  or x in "()",st)
+        s = dropTill(lambda x: not x in " \r\n"  or x in "()",st)
         if not s: break
         n = s[0]
 
@@ -115,7 +115,7 @@ def parseItem(st):
 def parse(st):
     ret = []
     while True:
-        step = dropWhile(lambda x: x in " \n",st)
+        step = dropWhile(lambda x: x in " \n\r",st)
         if step:
             if step[0:2] == ";;":
                 if "\n" in step:


### PR DESCRIPTION
parser.py did not deal correctly with "\r" characters. I made it skip those characters in the two places it skips "\n" characters.
